### PR TITLE
feat: Add initial state to fill empty space

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -65,6 +65,21 @@
                     <span class="block sm:inline" id="errorText">Something went wrong. Please try again.</span>
                 </div>
 
+                <div id="initialStateContainer" class="text-center text-white max-w-3xl mx-auto">
+                    <div class="bg-white/10 backdrop-blur-sm rounded-xl p-8">
+                        <h2 class="text-2xl font-bold mb-2">Welcome to Outliny!</h2>
+                        <p class="text-purple-200 mb-6">Your personal AI strategist. Just type your goal above and watch the magic happen. Or, try one of our examples to get started:</p>
+                        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4" id="examplesContainer">
+                            <button class="example-prompt-btn">Launch a new tech startup</button>
+                            <button class="example-prompt-btn">Organize a community marathon</button>
+                            <button class="example-prompt-btn">Plan a 2-week trip to Japan</button>
+                            <button class="example-prompt-btn">Create a personal fitness plan</button>
+                            <button class="example-prompt-btn">Write a fantasy novel</button>
+                            <button class="example-prompt-btn">Start a weekly podcast</button>
+                        </div>
+                    </div>
+                </div>
+
                 <div id="flowOutput"></div>
             </div>
         </main>

--- a/public/script.js
+++ b/public/script.js
@@ -8,6 +8,8 @@ const flowOutput = document.getElementById('flowOutput');
 const aboutModal = document.getElementById('aboutModal');
 const openAboutBtn = document.getElementById('openAboutBtn');
 const closeAboutBtn = document.getElementById('closeAboutBtn');
+const initialStateContainer = document.getElementById('initialStateContainer');
+const examplesContainer = document.getElementById('examplesContainer');
 
 // --- Event Listeners ---
 generateBtn.addEventListener('click', generateFlow);
@@ -16,6 +18,22 @@ goalInput.addEventListener('keyup', (event) => {
         generateFlow();
     }
 });
+
+goalInput.addEventListener('input', () => {
+    if (goalInput.value.trim() === '') {
+        flowOutput.innerHTML = '';
+        errorMessage.classList.add('hidden');
+        initialStateContainer.classList.remove('hidden');
+    }
+});
+
+examplesContainer.addEventListener('click', (event) => {
+    if (event.target.tagName === 'BUTTON') {
+        goalInput.value = event.target.textContent;
+        generateFlow();
+    }
+});
+
 
 // --- About Modal Logic ---
 openAboutBtn.addEventListener('click', () => {
@@ -42,6 +60,7 @@ async function generateFlow() {
         return;
     }
 
+    initialStateContainer.classList.add('hidden');
     flowOutput.innerHTML = '';
     errorMessage.classList.add('hidden');
     loader.classList.remove('hidden');
@@ -228,6 +247,8 @@ document.addEventListener('click', function(e) {
 function showError(message) {
     errorText.textContent = message;
     errorMessage.classList.remove('hidden');
+    flowOutput.innerHTML = '';
+    initialStateContainer.classList.remove('hidden');
 }
 
 function updateProgress() {

--- a/public/style.css
+++ b/public/style.css
@@ -59,3 +59,20 @@ body {
 .animate-fade-in-up {
     animation: fade-in-up 0.3s ease-out forwards;
 }
+
+.example-prompt-btn {
+    background-color: rgba(255, 255, 255, 0.1);
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    color: white;
+    padding: 12px;
+    border-radius: 8px;
+    text-align: center;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+    font-weight: 500;
+}
+
+.example-prompt-btn:hover {
+    background-color: rgba(255, 255, 255, 0.2);
+    transform: translateY(-2px);
+}


### PR DESCRIPTION
This commit adds an initial state to the main page to fill the empty space that was previously visible before a user generated a plan.

The new initial state includes:
- A welcome message introducing the application.
- A list of clickable example prompts to help users get started.

The initial state is hidden when a user starts generating a plan, and it reappears if the input is cleared or an error occurs.